### PR TITLE
Add Meta PC Check

### DIFF
--- a/Pages/Player.cs
+++ b/Pages/Player.cs
@@ -379,6 +379,8 @@ Creation Date");
                 return "Steam";
             else if (concatStringOfCosmeticsAllowed.Contains("FIRST LOGIN") || rig.Creator.GetPlayerRef().CustomProperties.Count >= 2)
                 return "PC";
+            else if (concatStringOfCosmeticsAllowed.Contains("game-purchase"))
+                return "OWNS META PC";
 
             return "Standalone";
         }


### PR DESCRIPTION
Adds checking for "game-purchase" aka game-purchase-bundle (both of which work), and reassuring that it only shows that they own it because standalone players can also have this, but this reassures that there is a chance that they are on quest pc (holy yap).